### PR TITLE
fix syntax error

### DIFF
--- a/wellfare/__init__.py
+++ b/wellfare/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
 
     # from .io
 
-    "load_WI_JSON"
+    "load_WI_JSON",
 
     # from .parsing
 


### PR DESCRIPTION
There is a syntax error in the __init__ of the wellfare package, fixed in this pull request.

The bug originally prevents us to import the package.